### PR TITLE
fix(web): hide artist aliases label when no aliases exist

### DIFF
--- a/web/src/view/artist/profile/comp/ArtistInfo.tsx
+++ b/web/src/view/artist/profile/comp/ArtistInfo.tsx
@@ -38,26 +38,28 @@ function Aliases() {
 	const context = assertContext(ArtistContext)
 	const aliases = createMemo(() => getInfoAliases(context.artist))
 	return (
-		<div>
-			<InfoLabel>Aliases</InfoLabel>
-			<ul class="flex flex-row gap-1">
-				<For each={aliases()}>
-					{(alias, index) => (
-						<>
-							<li>
-								<Show
-									when={alias.id}
-									fallback={alias.name}
-								>
-									{alias.id}
-								</Show>
-								<Show when={aliases().length - 1 > index()}>{", "}</Show>
-							</li>
-						</>
-					)}
-				</For>
-			</ul>
-		</div>
+		<Show when={aliases().length > 0}>
+			<div>
+				<InfoLabel>Aliases</InfoLabel>
+				<ul class="flex flex-row gap-1">
+					<For each={aliases()}>
+						{(alias, index) => (
+							<>
+								<li>
+									<Show
+										when={alias.id}
+										fallback={alias.name}
+									>
+										{alias.id}
+									</Show>
+									<Show when={aliases().length - 1 > index()}>{", "}</Show>
+								</li>
+							</>
+						)}
+					</For>
+				</ul>
+			</div>
+		</Show>
 	)
 }
 


### PR DESCRIPTION
### Motivation
- The artist profile page always showed the `Aliases` label even when there were no `aliases` or `text_aliases`, producing an empty/incorrect UI section.

### Description
- Wrapped the aliases block in `web/src/view/artist/profile/comp/ArtistInfo.tsx` with `<Show when={aliases().length > 0}>` so the `Aliases` label and list are only rendered when alias entries exist.

### Testing
- Ran `pnpm -C web check` (which runs `prettier --check ./src`) and it passed; `just fmt` and `just check` were attempted but `just` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dfc3d3bc8332af2218dabfbb6165)