### PR TITLE
Fix generated song lyrics relation

### DIFF
--- a/server/crates/entity/src/entities/song.rs
+++ b/server/crates/entity/src/entities/song.rs
@@ -30,7 +30,7 @@ pub enum Relation {
     SongLanguage,
     #[sea_orm(has_many = "super::song_localized_title::Entity")]
     SongLocalizedTitle,
-    #[sea_orm(has_one = "super::song_lyrics::Entity")]
+    #[sea_orm(has_many = "super::song_lyrics::Entity")]
     SongLyrics,
     #[sea_orm(has_many = "super::song_lyrics_history::Entity")]
     SongLyricsHistory,

--- a/server/crates/entity/src/entities/song_lyrics.rs
+++ b/server/crates/entity/src/entities/song_lyrics.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
-    #[sea_orm(unique)]
     pub song_id: i32,
     pub language_id: i32,
     #[sea_orm(column_type = "Text")]


### PR DESCRIPTION
## Summary

- model song lyrics as a has-many relation from songs
- remove the incorrect global uniqueness marker from song_lyrics.song_id
- allow song detail and explore queries to load all lyric rows without a relation cardinality error

## Verification

- server cargo fmt
- server cargo clippy
- server cargo test